### PR TITLE
chore: update default language to Korean

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   root: path.join(__dirname, 'docs'),
   title: '테크니컬 라이팅 가이드',
   icon: '/toss-logo.png',
+  lang: 'ko',
   logo: {
     light: '/toss-logo.png',
     dark: '/toss-logo.png',


### PR DESCRIPTION
Change the value of the `lang` attribute of the `html` tag to `ko`, since all content is served in Korean.