### PR TITLE
chore: update search placeholder to Korean

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
   globalStyles: path.join(__dirname, './styles/index.css'),
   themeConfig: {
     darkMode: false,
+    searchPlaceholderText: '검색',
     socialLinks: [
       {
         icon: 'github',


### PR DESCRIPTION
## 수정한 내용

<!-- 예: 문서 구조 만들기 섹션에 예시 문장 추가, 문장 다듬기 가이드 오타 수정 등 -->

검색창의 플레이스홀더를 한글로 번역합니다.

toss의 다른 문서 웹 사이트들과 동일하게 `검색`이라는 키워드로 번역하였습니다.

## 이 변경이 필요한 이유 (선택)

<!-- 예: 예시가 부족해서 이해가 어렵다는 피드백을 받았어요 / 가이드 문체 일관성을 맞추기 위해 수정했어요 -->

모든 문서가 한글로 제공되므로, 검색 창의 플레이스홀더도 한글로 번역하였습니다.

## 체크리스트

- [ ] 문서 가이드에 맞게 작성했어요.
- [x] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [x] 오타나 잘못된 정보는 없는지 검토했어요.
- [ ] 관련된 이슈가 있다면 아래에 연결했어요.
