### PR TITLE
fix(#3): improve Hero tagline readability on mobile devices

### DIFF
--- a/styles/rspress.css
+++ b/styles/rspress.css
@@ -16,3 +16,19 @@
   padding-top: 0;
   padding-bottom: 0;
 }
+
+.rspress-home-hero-tagline {
+  font-size: 0.875rem !important; /* text-sm */
+}
+
+@media (min-width: 640px) {
+  .rspress-home-hero-tagline {
+    font-size: 1.25rem !important; /* text-xl */
+  }
+}
+
+@media (min-width: 768px) {
+  .rspress-home-hero-tagline {
+    font-size: 1.5rem !important;
+  }
+}


### PR DESCRIPTION
## 수정한 내용
Hero 섹션의 tagline 텍스트 크기를 모바일 환경에 맞게 최적화했습니다.
styles/rspress.css에 반응형 스타일을 추가하여 다음과 같이 수정했습니다:
```
.rspress-home-hero-tagline {
  font-size: 0.875rem !important; /* text-sm */
}

@media (min-width: 640px) {
  .rspress-home-hero-tagline {
    font-size: 1.25rem !important; /* text-xl */
  }
}

@media (min-width: 768px) {
  .rspress-home-hero-tagline {
    font-size: 1.5rem !important;
  }
}
```

<table>
  <tr>
    <td align="center">
      <p><strong>BEFORE</strong></p>
      <img width="400" alt="image1" src="https://github.com/user-attachments/assets/f2f7abc0-916e-4b69-a6c7-dff484bc7f8b" />
    </td>
    <td align="center">
      <p><strong>AFTER</strong></p>
      <img width="400" alt="image2" src="https://github.com/user-attachments/assets/0cbf748c-e969-4151-b5f0-acf2e23e768f" />
    </td>
  </tr>
</table>




## 이 변경이 필요한 이유 (선택)

모바일 환경에서 tagline 텍스트가 너무 작아 가독성이 떨어지는 문제가 있었습니다.

원인을 파악해보니 node_modules/@rspress/theme-default/src/components/HomeHero/index.tsx에서 다음과 같은 오타를 발견했습니다:

```
<p
  className={`rspress-home-hero-tagline whitespace-pre-wrap pt-4 m-auto md:m-0 text-sm sm:tex-xl md:text-[1.5rem] text-text-2 font-medium z-10 ${textMaxWidth}`}
>
  {renderHtmlOrText(hero.tagline)}
</p>
```

sm:tex-xl 오타(text-xl이 되어야 함)가 있어 의도한 대로 스타일이 적용되지 않았습니다.

node_modules 내부의 코드를 직접 수정할 수 없어 CSS 오버라이드 방식으로 해결했습니다.


## 체크리스트

- [x] 문서 가이드에 맞게 작성했어요.
- [x] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [x] 오타나 잘못된 정보는 없는지 검토했어요.
- [x] 관련된 이슈가 있다면 아래에 연결했어요.

## 관련된 이슈: https://github.com/toss/technical-writing/issues/3