### PR TITLE
fix(#2): Resolve layout overlap between explanationPanel and aside-container

### DIFF
--- a/docs/shared/components/DocExample.module.css
+++ b/docs/shared/components/DocExample.module.css
@@ -237,7 +237,7 @@
     line-height: 1.6;
   }
 
-  @media (max-width: 768px) {
+  @media (min-width: 1280px) {
     .mainContent {
       grid-template-columns: 1fr;
     }


### PR DESCRIPTION
## 수정한 내용
화면 너비 1280px 이상에서 발생하는 explanationPanel과 aside-container의 레이아웃 겹침 문제를 해결했습니다.

기존의 스타일 코드에서 아래의 미디어 쿼리가 중복으로 있는 것을 발견하여 그 중 하나를 수정했습니다.
```
@media (max-width: 768px) {
  .mainContent {
    grid-template-columns: 1fr;
  }
  
  .codePanel {
    position: static;
  }
}
```

```
@media (min-width: 1280px) {
  .mainContent {
    grid-template-columns: 1fr;
  }

  .codePanel {
    position: static;
  }
}
```

<table>
  <tr>
    <td align="center">
      <p><strong>BEFORE</strong></p>
      <img width="400" alt="image1" src="https://github.com/user-attachments/assets/17c271d9-2ec9-4391-b424-a765cd9b6f17" />
    </td>
    <td align="center">
      <p><strong>AFTER</strong></p>
      <img width="400" alt="image2" src="https://github.com/user-attachments/assets/099610d9-a014-4ee7-afb7-13bc6b44a326" />
    </td>
  </tr>
</table>

## 체크리스트

- [x] 문서 가이드에 맞게 작성했어요.
- [x] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [x] 오타나 잘못된 정보는 없는지 검토했어요.
- [x] 관련된 이슈가 있다면 아래에 연결했어요.

## 관련이슈: https://github.com/toss/technical-writing/issues/2
