### PR TITLE
fix: fix typo in explanation document

### DIFF
--- a/docs/tutorial/structure.mdx
+++ b/docs/tutorial/structure.mdx
@@ -76,7 +76,7 @@ nextjs-performance-optimization/
 
 - [학습을 위한 문서](../type/learning.md)는 전체적인 흐름과 개요를 이해하는 걸로 시작해요. 필요하다면 실습, 심화 문제 해결의 계층을 가질 수 있어요.
 
-- [문제 해결을 위한 문서](../type/problem-solving.md)나 [설명 문서](../type/explaination.md)의 구조는 단계적이지 않고 같은 레벨의 문서로 구성될 수 있어요.
+- [문제 해결을 위한 문서](../type/problem-solving.md)나 [설명 문서](../type/explanation.md)의 구조는 단계적이지 않고 같은 레벨의 문서로 구성될 수 있어요.
 
 - [참조 문서](../type/reference.md)는 새로운 페이지에서 따로 목록을 제공할 수 있어요.
 


### PR DESCRIPTION
## 수정한 내용

<!-- 예: 문서 구조 만들기 섹션에 예시 문장 추가, 문장 다듬기 가이드 오타 수정 등 -->

[이전 PR1](https://github.com/toss/technical-writing/commit/3303d43a692200e4625edb71d4ad7f84dbfbc45a)과 [이전 PR2](https://github.com/toss/technical-writing/commit/f302c47202c5d2dc15b4826aa924607433cf5d37)이 병합되는 과정에서 다시 문서 철자가 변경돼 깨진 링크가 된 것을 수정했습니다. 

> branch protection rule 설정이 필요합니다. 

master branch에 병합할 때 `Require status checks to pass before merging`룰에 docs-build를 켜주세요.

## 이 변경이 필요한 이유 (선택)

<!-- 예: 예시가 부족해서 이해가 어렵다는 피드백을 받았어요 / 가이드 문체 일관성을 맞추기 위해 수정했어요 -->

## 체크리스트

- [ ] 문서 가이드에 맞게 작성했어요.
- [ ] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [ ] 오타나 잘못된 정보는 없는지 검토했어요.
- [ ] 관련된 이슈가 있다면 아래에 연결했어요.
