### PR TITLE
fix: Improve layout of explanationPanel for better readability and balance

### DIFF
--- a/docs/shared/components/DocExample.module.css
+++ b/docs/shared/components/DocExample.module.css
@@ -133,14 +133,16 @@
     font-size: 14px;
     padding: 10px;
   }
-  /* 오른쪽 패널: 설명 섹션 */
+
   .explanationPanel {
-    width: 300px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 30px;
     background-color: var(--explanation-bg);
     border-left: 1px solid var(--doc-border);
     flex-shrink: 0;
     position: relative;
-    padding-top: 85px; /* tabs + header 높이 */
+    padding: 20px 0;
     height: 100%;
   }
   
@@ -177,17 +179,15 @@
     font-size: 0.875rem;
     color: #4b5563;
     line-height: 1.6;
+    width: 300px;
   }
   
-  /* 반응형 */
-  @media (max-width: 768px) {
-    .mainContent {
-      grid-template-columns: 1fr;
-    }
-    
-    .codePanel {
-      position: static;
-    }
+  .mainContent {
+    grid-template-columns: 1fr;
+  }
+  
+  .codePanel {
+    position: static;
   }
   
   .codeLine {

--- a/docs/shared/components/DocExample.module.css
+++ b/docs/shared/components/DocExample.module.css
@@ -181,13 +181,15 @@
     line-height: 1.6;
     width: 300px;
   }
-  
-  .mainContent {
-    grid-template-columns: 1fr;
-  }
-  
-  .codePanel {
-    position: static;
+
+  @media (max-width: 1280px) {
+    .mainContent {
+      grid-template-columns: 1fr;
+    }
+    
+    .codePanel {
+      position: static;
+    }
   }
   
   .codeLine {


### PR DESCRIPTION
## 수정한 내용

- explanationPanel의 레이아웃을 개선하여, 이전에는 한쪽 정렬로 인해 우측 여백이 비정상적으로 넓었던 문제를 해결했습니다.
- 콘텐츠가 화면 너비를 더 자연스럽게 채우도록 하여 시각적 집중도를 높이고 가독성을 개선했습니다.

### [Before]
<img src = "https://github.com/user-attachments/assets/3e9322fc-b6b6-4ffc-a55d-4e7577f2aa78" />

### [After]
<img src = "https://github.com/user-attachments/assets/478a33ed-36d1-4a5e-b83a-31e0b38075b4" />



## 이 변경이 필요한 이유 (선택)

- 이전 레이아웃은 사용자가 집중해서 내용을 읽기 어려울 정도로 우측 공백이 과도하게 많아 가독성 저하가 있었습니다.
- 본 변경은 모바일 및 태블릿 대응 시에도 보다 유연하게 반응하도록 고려되었습니다.

## 체크리스트

- [x] 문서 가이드에 맞게 작성했어요.
- [x] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [x] 오타나 잘못된 정보는 없는지 검토했어요.
- [x] 관련된 이슈가 있다면 아래에 연결했어요.
