### PR TITLE
fix: add spacing between nav menu and github icon

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -1,7 +1,7 @@
 @import './rspress.css';
 @import './normalize.css';
 
-:root{
+:root {
   --rp-home-hero-name-color: #222;
   --rp-c-text-2: #333;
 }
@@ -13,4 +13,10 @@
 
 .button_72e53.brand_72e53 {
   background: #2272eb;
+}
+
+.container_457e8 {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -15,8 +15,6 @@
   background: #2272eb;
 }
 
-.container_457e8 {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+div.social-links {
+  margin-top: 0.75rem;
 }


### PR DESCRIPTION
## 수정한 내용

<!-- 예: 문서 구조 만들기 섹션에 예시 문장 추가, 문장 다듬기 가이드 오타 수정 등 -->
반응형 레이아웃(768px 미만)일 때 헤더 우측 "..." 버튼을 눌러서 나오는 navMenu와 github 아이콘 사이 간격을 조정했어요.

### 수정 전
<img width="1822" alt="스크린샷 2025-05-12 오후 8 55 50" src="https://github.com/user-attachments/assets/98e3441a-bdbf-4ed6-ae00-4554a7202f65" />

### 수정 후
<img width="1822" alt="스크린샷 2025-05-12 오후 8 56 51" src="https://github.com/user-attachments/assets/320f5d5a-c5fb-42f8-a7fe-54e2524b9e4d" />

navMenu와 github 아이콘 사이 간격은 navMenuItem의 상단 padding 값을 참고하여 12px(0.75rem)로 설정했어요.

## 이 변경이 필요한 이유 (선택)

<!-- 예: 예시가 부족해서 이해가 어렵다는 피드백을 받았어요 / 가이드 문체 일관성을 맞추기 위해 수정했어요 -->

## 체크리스트

- [x] 문서 가이드에 맞게 작성했어요.
- [x] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [x] 오타나 잘못된 정보는 없는지 검토했어요.
- [x] 관련된 이슈가 있다면 아래에 연결했어요.
