### PR TITLE
fix: social links margin for responsive layout

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -15,6 +15,8 @@
   background: #2272eb;
 }
 
-div.social-links {
-  margin-top: 0.75rem;
+@media (max-width: 768px) {
+  div.social-links {
+    margin-top: 0.75rem;
+  }
 }


### PR DESCRIPTION
## 수정한 내용

<!-- 예: 문서 구조 만들기 섹션에 예시 문장 추가, 문장 다듬기 가이드 오타 수정 등 -->
소셜 링크 마진을 뷰가 768px 이하일 때만 적용해요. 

## 이 변경이 필요한 이유 (선택)

<!-- 예: 예시가 부족해서 이해가 어렵다는 피드백을 받았어요 / 가이드 문체 일관성을 맞추기 위해 수정했어요 -->

## 체크리스트

- [ ] 문서 가이드에 맞게 작성했어요.
- [ ] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [ ] 오타나 잘못된 정보는 없는지 검토했어요.
- [ ] 관련된 이슈가 있다면 아래에 연결했어요.
