### PR TITLE
docs: fix lineEnd

### DIFF
--- a/docs/type/content/reference.ts
+++ b/docs/type/content/reference.ts
@@ -107,7 +107,7 @@ fetchData();
         {
             "explanation": "fetch 함수의 매개변수와 반환값을 정리해요. Response 객체의 주요 속성을 나열하고, 반환값을 다루는 방법을 쉽게 이해할 수 있도록 했습니다.",
             "lineStart": 12,
-            "lineEnd": 30
+            "lineEnd": 33
         },
         {
             "explanation": "기본적인 사용 예제를 제공해요. fetch를 활용하여 데이터를 가져오는 방법과 오류 처리를 함께 설명했습니다.",


### PR DESCRIPTION
## 수정한 내용

<!-- 예: 문서 구조 만들기 섹션에 예시 문장 추가, 문장 다듬기 가이드 오타 수정 등 -->

https://technical-writing.dev/type/reference.html 문서의 3번 하이라이팅 범위를 수정했습니다.

기존:

<img width="664" alt="image" src="https://github.com/user-attachments/assets/3b85df86-7242-4763-8b82-77e1ec5e3816" />

## 이 변경이 필요한 이유 (선택)

<!-- 예: 예시가 부족해서 이해가 어렵다는 피드백을 받았어요 / 가이드 문체 일관성을 맞추기 위해 수정했어요 -->

## 체크리스트

- [ ] 문서 가이드에 맞게 작성했어요.
- [ ] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [ ] 오타나 잘못된 정보는 없는지 검토했어요.
- [ ] 관련된 이슈가 있다면 아래에 연결했어요.
