### PR TITLE
fix: update DoDont.module.css

### DIFF
--- a/components/DoDont/DoDont.module.css
+++ b/components/DoDont/DoDont.module.css
@@ -1,7 +1,13 @@
 .container {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
   gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .container {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .directive {
@@ -10,6 +16,12 @@
   border-radius: 0.375rem;
   padding: 1rem;
   margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.directive pre {
+  overflow-x: auto;
+  max-width: 100%;
 }
 
 .directiveTitle {


### PR DESCRIPTION
> [!NOTE]
> 안녕하세요, 프로젝트에 관심이 생겨서 둘러보던 중 이슈를 발견하게 되었어요.  
> 별도의 기여 가이드가 없어서 조심스럽지만 작게나마 기여해봤어요.  
> 외부 PR을 받지 않으신다면 참고만 해주셔도 좋을 것 같아요!

## 수정한 내용

`DoDont` 컴포넌트에서 모바일 환경의 가로 스크롤 문제를 수정했어요.
- 그리드 레이아웃에 반응형을 적용했어요. 기존에는 화면 크기와 관계없이 항상 2열로 표시되었는데, 모바일에서는 1열로 표시되고 768px 이상에서만 2열로 표시되도록 수정했어요.
- `pre` 요소에 `overflow-x: auto`와 `max-width: 100%`를 적용해서 코드 블록이 컨테이너를 벗어나지 않고 내부에서 스크롤되도록 처리했어요.

| As-is | To-be |
|:---:|:---:|
| <img width="313" alt="As-is" src="https://github.com/user-attachments/assets/74086564-8e79-4ec4-bb56-d9702b377f9d" /> | <img width="309" alt="To-be" src="https://github.com/user-attachments/assets/3c8b4dc9-9f75-47d5-8a0e-36c0d6ebb0f4" /> |

## 이 변경이 필요한 이유

#32 이슈에서 "한 페이지에서는 하나만 다루기" 페이지의 모바일 환경에서 가로 스크롤이 발생하고 빈 공간이 생기는 문제를 확인했어요. 2열 그리드가 좁은 화면에서 컨테이너를 벗어나고, 코드 블록도 부모 너비를 초과하면서 레이아웃이 깨지는 것으로 보여서 두 부분을 함께 수정했어요.

## 체크리스트

- [x] 문서 가이드에 맞게 작성했어요.
- [x] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [x] 오타나 잘못된 정보는 없는지 검토했어요.
- [x] 관련된 이슈가 있다면 아래에 연결했어요.

## 관련 이슈

Closes #32