### PR TITLE
chore: remove unused pluginOpenGraph import

### DIFF
--- a/rspress.config.ts
+++ b/rspress.config.ts
@@ -1,6 +1,5 @@
 import * as path from 'node:path';
 import { defineConfig } from 'rspress/config';
-import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),


### PR DESCRIPTION
## 수정한 내용

## Summary
Removes the unused `pluginOpenGraph` import from [rspress.config.ts]

path -> rspress.config.ts

## Changes
- Removed unused import: `import { pluginOpenGraph } from 'rsbuild-plugin-open-graph'`

## Ex img
<img width="715" height="79" alt="toss rspress" src="https://github.com/user-attachments/assets/971f25fa-aafa-4f35-b959-05030ed0fb8b" />

## Related Issue
Fix #37 

## 이 변경이 필요한 이유 (선택)

> Explain and Fix Problem

## 체크리스트

- [x] 문서 가이드에 맞게 작성했어요.
- [x] 기존 설명 흐름을 해치지 않고 자연스럽게 연결되도록 구성했어요.
- [x] 오타나 잘못된 정보는 없는지 검토했어요.
- [x] 관련된 이슈가 있다면 아래에 연결했어요.
